### PR TITLE
Feature/tngp 106 headline and level

### DIFF
--- a/components/body/Headline.js
+++ b/components/body/Headline.js
@@ -16,10 +16,14 @@
  * @param {string} props.children - any jsx elements
  * @return {jsx} - the Headline component to render
  */
-const Headline = ({ h1Text = 'What Matters to You!', children }) => {
+const Headline = ({
+  h1Text = 'What Matters to You!',
+  h1ClassName = 'display-2 fw-bolder',
+  children
+}) => {
   return (
     <div>
-      <h1 className="display-2 fw-bolder">{h1Text}</h1>
+      <h1 className={h1ClassName}>{h1Text}</h1>
       {children}
       <hr />
     </div>

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -42,8 +42,17 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
           </Tooltip>
           <span className="ms-2">{text}</span>
         </div>
-        <div className="mt-3">
-          <input type="range" min="1" max="10" className="w-100" />
+        <div className="mt-3 d-flex align-items-center">
+          <input
+            type="range"
+            min="1"
+            max="10"
+            className="w-75"
+            name="input-number"
+            onChange={handleInputChange}
+            value={inputValue}
+          />
+          <span className="ms-4">{inputValue}</span>
         </div>
       </div>
       {/* screen > 576px display ONLY big screen content */}

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -19,8 +19,14 @@ const Level = ({ icon }) => {
     <div className="border">
       <div className="icon">{icon}</div>
       <div>Level</div>
+      <div>Slider component goes here</div>
     </div>
   );
 };
 
 export default Level;
+
+/* pass in text as props
+ * add text & icon params to description
+ * work on layout - mobile vs desktop (mobile-first!)
+ */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -12,6 +12,8 @@
 
 /**
  * @description - returns icon, tooltip, text, and range slider
+ * @param {jsx} props.icon - Bootstrap icon
+ * @param {string} props.text - text to display
  * @return {jsx} - the Level component to render
  */
 const Level = ({ icon, text }) => {
@@ -26,7 +28,6 @@ const Level = ({ icon, text }) => {
 
 export default Level;
 
-/* pass in text as props
- * add text & icon params to description
+/*
  * work on layout - mobile vs desktop (mobile-first!)
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-present TrueChoice IP Holding Company, Inc.
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of TrueChoice IP Holding Company, Inc.
+ * ("Confidential Information").  You shall not disclose such Confidential Information and shall
+ * use it only in accordance with the terms of the license agreement you entered into with the company.
+ */
+
 const Level = ({ icon }) => {
   return (
     <div className="border">

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -15,6 +15,7 @@ import styles from './Level.module.css';
  * @description - returns icon, tooltip, text, and range slider
  * @param {jsx} props.icon - Bootstrap icon
  * @param {string} props.text - text to display
+ * @param {jsx} props.tooltip - Tooltip component
  * @return {jsx} - the Level component to render
  */
 const Level = ({ icon, text, tooltip }) => {

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -79,6 +79,6 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
 export default Level;
 
 /*
- * make text equal height on medium+ screens
- * create a range slider for each level
+ *
+ * style range slider so it's consistent across all browsers (difficult...)
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -10,6 +10,7 @@
 // dependencies
 // local files
 import styles from './Level.module.css';
+import Tooltip from '../shared/Tooltip';
 
 /**
  * @description - returns icon, tooltip, text, and range slider
@@ -19,11 +20,12 @@ import styles from './Level.module.css';
  */
 const Level = ({ icon, text }) => {
   return (
-    <div className="border">
+    <div className="">
       {/* screen < 576px display ONLY small screen content */}
-      <div className={styles.smallScreenContent}>
+      <div className={`${styles.smallScreenContent} border`}>
         <div>
-          TT <span>{text}</span>
+          <Tooltip />
+          <span>{text}</span>
         </div>
         <div>Slider component goes here SMALL</div>
       </div>

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -8,6 +8,7 @@
  */
 
 // dependencies
+import { Row, Col } from 'react-bootstrap';
 // local files
 import styles from './Level.module.css';
 import Tooltip from '../shared/Tooltip';
@@ -36,10 +37,9 @@ const Level = ({ icon, text, tooltipContent }) => {
         Slider component goes here SMALL
       </div>
       {/* screen > 576px display ONLY big screen content */}
-      <div className={styles.regularScreenContent}>
-        <div className="icon">{icon}</div>
+      <div className={`${styles.regularScreenContent} p-2 text-center`}>
+        <div>{icon}</div>
         <div>{text}</div>
-        <div>Slider component goes here BIG</div>
       </div>
     </div>
   );
@@ -48,7 +48,6 @@ const Level = ({ icon, text, tooltipContent }) => {
 export default Level;
 
 /*
- * add tooltip content for other 5 levels, refactor. Not dry. Update description to tooltipContent
  * work on regular screen content
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -8,6 +8,7 @@
  */
 
 // dependencies
+import { useState } from 'react';
 // local files
 import styles from './Level.module.css';
 import Tooltip from '../shared/Tooltip';
@@ -20,6 +21,14 @@ import Tooltip from '../shared/Tooltip';
  * @return {jsx} - the Level component to render
  */
 const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
+  // state
+  const [inputValue, setInputValue] = useState('5');
+
+  // event handler
+  const handleInputChange = (event) => {
+    setInputValue(event.target.value);
+  };
+
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
@@ -58,7 +67,11 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
             type="range"
             min="1"
             max="10"
+            name="input-number"
+            onChange={handleInputChange}
+            value={inputValue}
           />
+          <div>{inputValue}</div>
         </div>
       </div>
     </div>

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -42,7 +42,7 @@ const Level = ({ icon, text, tooltip }) => {
 export default Level;
 
 /*
- * add tooltip content for other 5 levels
+ * add tooltip content for other 5 levels, refactor. Not dry
  * work on regular screen content
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -19,7 +19,7 @@ import Tooltip from '../shared/Tooltip';
  * @param {jsx} props.tooltipContent - Tooltip content to display
  * @return {jsx} - the Level component to render
  */
-const Level = ({ icon, text, tooltipContent }) => {
+const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
@@ -46,8 +46,10 @@ const Level = ({ icon, text, tooltipContent }) => {
           </div>
         </div>
 
-        <div className="mt-3 border">{text}</div>
-        {'Slider component goes here >= 768px'}
+        <div className="mt-3 border" style={{ height: `${textBoxHeightRem}` }}>
+          {text}
+        </div>
+        <div>{'Slider component goes here >= 768px'}</div>
       </div>
     </div>
   );

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -7,6 +7,13 @@
  * use it only in accordance with the terms of the license agreement you entered into with the company.
  */
 
+// dependencies
+// local files
+
+/**
+ * @description - returns icon, tooltip, text, and range slider
+ * @return {jsx} - the Level component to render
+ */
 const Level = ({ icon }) => {
   return (
     <div className="border">

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -39,7 +39,7 @@ const Level = ({ icon, text, tooltipContent }) => {
       <div className={`${styles.regularScreenContent} p-2 text-center`}>
         <div className="position-relative d-inline-block">
           {icon}
-          <div className="position-absolute border top-100 start-100 translate-middle ms-3">
+          <div className="position-absolute top-100 start-100 translate-middle ms-3">
             <Tooltip contentClassName="bg-dark p-3 text-center">
               {tooltipContent}
             </Tooltip>
@@ -56,7 +56,6 @@ const Level = ({ icon, text, tooltipContent }) => {
 export default Level;
 
 /*
- * fix tooltip, try to refactor: top tooltip and hr conflicting
  * make text equal height on medium+ screens
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -20,6 +20,10 @@ import Tooltip from '../shared/Tooltip';
  * @return {jsx} - the Level component to render
  */
 const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
+  const handleInputChange = (event) => {
+    console.log(event.target.value);
+  };
+
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
@@ -33,7 +37,15 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
           </Tooltip>
           <span className="ms-2">{text}</span>
         </div>
-        {'Slider component goes here < 768px'}
+        <div className="mt-3">
+          <input
+            type="range"
+            min="1"
+            max="10"
+            onChange={handleInputChange}
+            className={`w-100 ${styles.inputRange}`}
+          />
+        </div>
       </div>
       {/* screen > 576px display ONLY big screen content */}
       <div className={`${styles.regularScreenContent} p-2 text-center`}>

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -37,8 +37,19 @@ const Level = ({ icon, text, tooltipContent }) => {
       </div>
       {/* screen > 576px display ONLY big screen content */}
       <div className={`${styles.regularScreenContent} p-2 text-center`}>
-        <div>{icon}</div>
-        <div>{text}</div>
+        <div className="position-relative d-inline-block">
+          {icon}
+          <div
+            className="position-absolute top-100 start-100 translate-middle ms-3"
+            style={{ zIndex: '1' }}
+          >
+            <Tooltip contentClassName="bg-dark p-3 text-center">
+              {tooltipContent}
+            </Tooltip>
+          </div>
+        </div>
+
+        <div className="mt-3 border">{text}</div>
         {'Slider component goes here >= 768px'}
       </div>
     </div>
@@ -48,6 +59,6 @@ const Level = ({ icon, text, tooltipContent }) => {
 export default Level;
 
 /*
- * work on regular screen content - implement tooltip on larger screen
+ * make text equal height on medium+ screens
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -42,5 +42,7 @@ const Level = ({ icon, text, tooltip }) => {
 export default Level;
 
 /*
- * work on layout - mobile vs desktop (mobile-first!)
+ * add tooltip content for other 5 levels
+ * work on regular screen content
+ * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -8,7 +8,6 @@
  */
 
 // dependencies
-import { Row, Col } from 'react-bootstrap';
 // local files
 import styles from './Level.module.css';
 import Tooltip from '../shared/Tooltip';
@@ -34,12 +33,13 @@ const Level = ({ icon, text, tooltipContent }) => {
           </Tooltip>
           <span className="ms-2">{text}</span>
         </div>
-        Slider component goes here SMALL
+        {'Slider component goes here < 768px'}
       </div>
       {/* screen > 576px display ONLY big screen content */}
       <div className={`${styles.regularScreenContent} p-2 text-center`}>
         <div>{icon}</div>
         <div>{text}</div>
+        {'Slider component goes here >= 768px'}
       </div>
     </div>
   );
@@ -48,6 +48,6 @@ const Level = ({ icon, text, tooltipContent }) => {
 export default Level;
 
 /*
- * work on regular screen content
+ * work on regular screen content - implement tooltip on larger screen
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -16,7 +16,7 @@ import Tooltip from '../shared/Tooltip';
  * @description - returns icon, tooltip, text, and range slider
  * @param {jsx} props.icon - Bootstrap icon
  * @param {string} props.text - text to display
- * @param {jsx} props.tooltip - Tooltip component
+ * @param {jsx} props.tooltipContent - Tooltip content to display
  * @return {jsx} - the Level component to render
  */
 const Level = ({ icon, text, tooltipContent }) => {

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -10,7 +10,6 @@
 // dependencies
 // local files
 import styles from './Level.module.css';
-import Tooltip from '../shared/Tooltip';
 
 /**
  * @description - returns icon, tooltip, text, and range slider
@@ -18,15 +17,13 @@ import Tooltip from '../shared/Tooltip';
  * @param {string} props.text - text to display
  * @return {jsx} - the Level component to render
  */
-const Level = ({ icon, text }) => {
+const Level = ({ icon, text, tooltip }) => {
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
       <div className={`${styles.smallScreenContent} border p-2`}>
         <div className="border border-primary d-flex align-items-center">
-          <Tooltip>
-            <p>Employee assistance program tooltip</p>
-          </Tooltip>
+          {tooltip}
           <span className="ms-2">{text}</span>
         </div>
         Slider component goes here SMALL

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -9,6 +9,7 @@
 
 // dependencies
 // local files
+import styles from './Level.module.css';
 
 /**
  * @description - returns icon, tooltip, text, and range slider
@@ -19,11 +20,19 @@
 const Level = ({ icon, text }) => {
   return (
     <div className="border">
-      {/* screen < 576px */}
-      <div className="icon">{icon}</div>
-      <div>{text}</div>
-      <div>Slider component goes here</div>
-      {/* screen > 576px */}
+      {/* screen < 576px display ONLY small screen content */}
+      <div className={styles.smallScreenContent}>
+        <div>
+          TT <span>{text}</span>
+        </div>
+        <div>Slider component goes here SMALL</div>
+      </div>
+      {/* screen > 576px display ONLY big screen content */}
+      <div className={styles.regularScreenContent}>
+        <div className="icon">{icon}</div>
+        <div>{text}</div>
+        <div>Slider component goes here BIG</div>
+      </div>
     </div>
   );
 };

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -27,8 +27,8 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
-      <div className={`${styles.smallScreenContent} border p-2`}>
-        <div className="border border-primary d-flex align-items-center">
+      <div className={`${styles.smallScreenContent} p-2`}>
+        <div className="d-flex align-items-center">
           <Tooltip
             contentClassName="bg-dark p-3 text-center"
             contentAbsoluteStartingPosition="left"
@@ -58,10 +58,19 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
           </div>
         </div>
 
-        <div className="mt-3 border" style={{ height: `${textBoxHeightRem}` }}>
+        <div className="mt-3" style={{ height: `${textBoxHeightRem}` }}>
           {text}
         </div>
-        <div>{'Slider component goes here >= 768px'}</div>
+        <div className="mt-3">
+          <input
+            orient="vertical"
+            type="range"
+            min="1"
+            max="10"
+            onChange={handleInputChange}
+            className={`w-100 ${styles.inputRange}`}
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -1,6 +1,7 @@
-const Level = () => {
+const Level = ({ icon }) => {
   return (
-    <div>
+    <div className="border">
+      <div className="icon">{icon}</div>
       <div>Level</div>
     </div>
   );

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -19,9 +19,11 @@
 const Level = ({ icon, text }) => {
   return (
     <div className="border">
+      {/* screen < 576px */}
       <div className="icon">{icon}</div>
       <div>{text}</div>
       <div>Slider component goes here</div>
+      {/* screen > 576px */}
     </div>
   );
 };

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -25,6 +25,10 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
   const [inputValue, setInputValue] = useState('5');
 
   // event handler
+  /**
+   * @description - stores input range value into 'inputValue' state
+   * @param {object} event - get user's value from interacting with range slider
+   */
   const handleInputChange = (event) => {
     setInputValue(event.target.value);
   };

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -20,14 +20,14 @@ import Tooltip from '../shared/Tooltip';
  */
 const Level = ({ icon, text }) => {
   return (
-    <div className="">
+    <div>
       {/* screen < 576px display ONLY small screen content */}
-      <div className={`${styles.smallScreenContent} border`}>
-        <div>
+      <div className={`${styles.smallScreenContent} border p-2`}>
+        <div className="border border-primary d-flex align-items-center">
           <Tooltip />
-          <span>{text}</span>
+          <span className="ms-2">{text}</span>
         </div>
-        <div>Slider component goes here SMALL</div>
+        Slider component goes here SMALL
       </div>
       {/* screen > 576px display ONLY big screen content */}
       <div className={styles.regularScreenContent}>

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -1,0 +1,9 @@
+const Level = () => {
+  return (
+    <div>
+      <div>Level</div>
+    </div>
+  );
+};
+
+export default Level;

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -14,11 +14,11 @@
  * @description - returns icon, tooltip, text, and range slider
  * @return {jsx} - the Level component to render
  */
-const Level = ({ icon }) => {
+const Level = ({ icon, text }) => {
   return (
     <div className="border">
       <div className="icon">{icon}</div>
-      <div>Level</div>
+      <div>{text}</div>
       <div>Slider component goes here</div>
     </div>
   );

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -10,6 +10,7 @@
 // dependencies
 // local files
 import styles from './Level.module.css';
+import Tooltip from '../shared/Tooltip';
 
 /**
  * @description - returns icon, tooltip, text, and range slider
@@ -18,13 +19,18 @@ import styles from './Level.module.css';
  * @param {jsx} props.tooltip - Tooltip component
  * @return {jsx} - the Level component to render
  */
-const Level = ({ icon, text, tooltip }) => {
+const Level = ({ icon, text, tooltipContent }) => {
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
       <div className={`${styles.smallScreenContent} border p-2`}>
         <div className="border border-primary d-flex align-items-center">
-          {tooltip}
+          <Tooltip
+            contentClassName="bg-dark p-3 text-center"
+            contentAbsoluteStartingPosition="left"
+          >
+            {tooltipContent}
+          </Tooltip>
           <span className="ms-2">{text}</span>
         </div>
         Slider component goes here SMALL
@@ -42,7 +48,7 @@ const Level = ({ icon, text, tooltip }) => {
 export default Level;
 
 /*
- * add tooltip content for other 5 levels, refactor. Not dry
+ * add tooltip content for other 5 levels, refactor. Not dry. Update description to tooltipContent
  * work on regular screen content
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -39,10 +39,7 @@ const Level = ({ icon, text, tooltipContent }) => {
       <div className={`${styles.regularScreenContent} p-2 text-center`}>
         <div className="position-relative d-inline-block">
           {icon}
-          <div
-            className="position-absolute top-100 start-100 translate-middle ms-3"
-            style={{ zIndex: '1' }}
-          >
+          <div className="position-absolute border top-100 start-100 translate-middle ms-3">
             <Tooltip contentClassName="bg-dark p-3 text-center">
               {tooltipContent}
             </Tooltip>

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -59,6 +59,7 @@ const Level = ({ icon, text, tooltipContent }) => {
 export default Level;
 
 /*
+ * fix tooltip, try to refactor: top tooltip and hr conflicting
  * make text equal height on medium+ screens
  * create a range slider for each level
  */

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -24,7 +24,9 @@ const Level = ({ icon, text }) => {
       {/* screen < 576px display ONLY small screen content */}
       <div className={`${styles.smallScreenContent} border p-2`}>
         <div className="border border-primary d-flex align-items-center">
-          <Tooltip />
+          <Tooltip>
+            <p>Employee assistance program tooltip</p>
+          </Tooltip>
           <span className="ms-2">{text}</span>
         </div>
         Slider component goes here SMALL

--- a/components/body/Level.js
+++ b/components/body/Level.js
@@ -20,10 +20,6 @@ import Tooltip from '../shared/Tooltip';
  * @return {jsx} - the Level component to render
  */
 const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
-  const handleInputChange = (event) => {
-    console.log(event.target.value);
-  };
-
   return (
     <div>
       {/* screen < 576px display ONLY small screen content */}
@@ -38,13 +34,7 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
           <span className="ms-2">{text}</span>
         </div>
         <div className="mt-3">
-          <input
-            type="range"
-            min="1"
-            max="10"
-            onChange={handleInputChange}
-            className={`w-100 ${styles.inputRange}`}
-          />
+          <input type="range" min="1" max="10" className="w-100" />
         </div>
       </div>
       {/* screen > 576px display ONLY big screen content */}
@@ -64,11 +54,10 @@ const Level = ({ icon, text, tooltipContent, textBoxHeightRem = '100%' }) => {
         <div className="mt-3">
           <input
             orient="vertical"
+            className="w-100"
             type="range"
             min="1"
             max="10"
-            onChange={handleInputChange}
-            className={`w-100 ${styles.inputRange}`}
           />
         </div>
       </div>

--- a/components/body/Level.module.css
+++ b/components/body/Level.module.css
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2006-present TrueChoice IP Holding Company, Inc.
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of TrueChoice IP Holding Company, Inc.
+ * ("Confidential Information").  You shall not disclose such Confidential Information and shall
+ * use it only in accordance with the terms of the license agreement you entered into with the company.
+ */
+
+.regularScreenContent {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .smallScreenContent {
+    display: none;
+  }
+
+  .regularScreenContent {
+    display: block;
+  }
+}

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -46,7 +46,7 @@ const LevelsContent = ({ attribute }) => {
               </Tooltip>
               <Badge
                 className="bg-primary d-inline-block rounded-pill px-2 ms-3"
-                text="Work / Life Balance"
+                text={attribute.name}
               />
             </div>
             <div className="mt-3">

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -31,7 +31,7 @@ const LevelsContent = ({ attribute }) => {
   const renderLevels = () => {
     return attribute.levels.map((level) => {
       /* Icons is object with nested bootstrap icon name objects. Gets object matching level.
-       * Rendering React components, so Icon variable must be capitalized.
+       * Rendering React components, so Icon variable must be capitalized. e.g.<Icon size={30} />
        */
       const Icon = Icons[level.icon];
 
@@ -75,7 +75,7 @@ const LevelsContent = ({ attribute }) => {
 
             <Row>{renderLevels()}</Row>
 
-            {/* Added div here to so main content
+            {/* Added div here so main content
              * isn't blocked by footer, has space to scroll to view all body content
              */}
             <div className={styles.marginDiv}></div>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -67,74 +67,34 @@ const LevelsContent = () => {
               <Level
                 icon={<PersonCheck size={30} />}
                 text="Employee assistance programs"
-                tooltip={
-                  <Tooltip
-                    contentClassName="bg-dark p-3 text-center"
-                    contentAbsoluteStartingPosition="left"
-                  >
-                    <p>Employee assistance programs tooltip!</p>
-                  </Tooltip>
-                }
+                tooltipContent={<p>Employee assistance programs tooltip!</p>}
               />
               <Level
                 icon={<Basket size={30} />}
                 text="Absence management and occupational health"
-                tooltip={
-                  <Tooltip
-                    contentClassName="bg-dark p-3 text-center"
-                    contentAbsoluteStartingPosition="left"
-                  >
-                    <p>Absence management and occupational health tooltip!</p>
-                  </Tooltip>
+                tooltipContent={
+                  <p>Absence management and occupational health tooltip!</p>
                 }
               />
               <Level
                 icon={<Diagram3 size={30} />}
                 text="Child care"
-                tooltip={
-                  <Tooltip
-                    contentClassName="bg-dark p-3 text-center"
-                    contentAbsoluteStartingPosition="left"
-                  >
-                    <p>Child care tooltip!</p>
-                  </Tooltip>
-                }
+                tooltipContent={<p>Child care tooltip!</p>}
               />
               <Level
                 icon={<HeartHalf size={30} />}
                 text="Stress management"
-                tooltip={
-                  <Tooltip
-                    contentClassName="bg-dark p-3 text-center"
-                    contentAbsoluteStartingPosition="left"
-                  >
-                    <p>Stress management tooltip!</p>
-                  </Tooltip>
-                }
+                tooltipContent={<p>Stress management tooltip!</p>}
               />
               <Level
                 icon={<PersonWorkspace size={30} />}
                 text="Flexible and remote working"
-                tooltip={
-                  <Tooltip
-                    contentClassName="bg-dark p-3 text-center"
-                    contentAbsoluteStartingPosition="left"
-                  >
-                    <p>Flexible and remote working tooltip!</p>
-                  </Tooltip>
-                }
+                tooltipContent={<p>Flexible and remote working tooltip!</p>}
               />
               <Level
                 icon={<HddNetwork size={30} />}
                 text="Workstation assessments"
-                tooltip={
-                  <Tooltip
-                    contentClassName="bg-dark p-3 text-center"
-                    contentAbsoluteStartingPosition="left"
-                  >
-                    <p>Workstation assessments tooltip!</p>
-                  </Tooltip>
-                }
+                tooltipContent={<p>Workstation assessments tooltip!</p>}
               />
             </div>
 

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -33,10 +33,10 @@ const LevelsContent = () => {
     <Container fluid>
       <Container>
         <Row
-          className={`position-relative w-100 h-100 align-items-center text-light ${styles.row}`}
+          className={`position-relative border align-items-center text-light ${styles.row}`}
         >
           <Col>
-            <div className="d-flex align-items-center">
+            <div className="d-flex align-items-center position-relative z-index-top">
               <Tooltip
                 contentClassName="bg-dark p-3 text-center"
                 contentAbsoluteStartingPosition="left"

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -31,7 +31,10 @@ const LevelsContent = () => {
   return (
     <Container fluid>
       <Container>
-        <Row className="vh-100 min-vh-100 align-items-center text-light">
+        <Row
+          style={{ top: '150px' }}
+          className="border position-relative w-100 h-100 align-items-center text-light"
+        >
           <Col>
             <div className="d-flex align-items-center">
               <Tooltip
@@ -61,7 +64,11 @@ const LevelsContent = () => {
               </Headline>
             </div>
             <div className="d-flex flex-column flex-sm-row">
-              <Level icon={<PersonCheck size={30} />} />
+              <Level
+                icon={
+                  <PersonCheck size={30} text="Employee assistance programs" />
+                }
+              />
               <Level icon={<Basket size={30} />} />
               <Level icon={<Diagram3 size={30} />} />
               <Level icon={<HeartHalf size={30} />} />

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -33,7 +33,7 @@ const LevelsContent = () => {
       <Container>
         <Row
           style={{
-            top: '9.375rem'
+            top: '8rem'
           }}
           className="position-relative w-100 h-100 align-items-center text-light"
         >
@@ -90,7 +90,7 @@ const LevelsContent = () => {
               />
             </div>
 
-            <div style={{ marginTop: '200px' }}></div>
+            <div style={{ marginTop: '10rem' }}></div>
           </Col>
         </Row>
       </Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -32,7 +32,9 @@ const LevelsContent = () => {
     <Container fluid>
       <Container>
         <Row
-          style={{ top: '9.375rem' }}
+          style={{
+            top: '9.375rem'
+          }}
           className="position-relative w-100 h-100 align-items-center text-light"
         >
           <Col>
@@ -65,16 +67,30 @@ const LevelsContent = () => {
             </div>
             <div className="d-flex flex-column flex-sm-row">
               <Level
+                icon={<PersonCheck size={30} />}
+                text="Employee assistance programs"
+              />
+              <Level
+                icon={<Basket size={30} />}
+                text="Absence management and occupational health"
+              />
+              <Level icon={<Diagram3 size={30} />} text="Child care" />
+              <Level icon={<HeartHalf size={30} />} text="Stress management" />
+              <Level
                 icon={
-                  <PersonCheck size={30} text="Employee assistance programs" />
+                  <PersonWorkspace
+                    size={30}
+                    text="Flexible and remote working"
+                  />
                 }
               />
-              <Level icon={<Basket size={30} />} />
-              <Level icon={<Diagram3 size={30} />} />
-              <Level icon={<HeartHalf size={30} />} />
-              <Level icon={<PersonWorkspace size={30} />} />
-              <Level icon={<HddNetwork size={30} />} />
+              <Level
+                icon={<HddNetwork size={30} />}
+                text="Workstation assessments"
+              />
             </div>
+
+            <div style={{ marginTop: '200px' }}></div>
           </Col>
         </Row>
       </Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -30,20 +30,31 @@ import Level from './Level';
  * @return {jsx} - the Levels One component to render
  */
 const LevelsContent = ({ attribute }) => {
+  const iconMap = {
+    Diagram3: <Diagram3 size={30} />,
+    Basket: <Basket size={30} />,
+    PersonCheck: <PersonCheck size={30} />,
+    HeartHalf: <HeartHalf size={30} />,
+    HddNetwork: <HddNetwork size={30} />,
+    PersonWorkspace: <PersonWorkspace size={30} />
+  };
+
   // render content
   const renderLevels = () => {
-    const mappedLevels = attribute.levels.map((level) => (
-      <Col key={level.name} md={2}>
-        <Level
-          icon={<level.icon size={30} />}
-          text={level.name}
-          tooltipContent={<p>{level.tooltipText}</p>}
-          textBoxHeightRem="7.6rem"
-        />
-      </Col>
-    ));
+    return attribute.levels.map((level) => {
+      let BootstrapIcon = iconMap[level.icon];
 
-    return mappedLevels;
+      return (
+        <Col key={level.name} md={2}>
+          <Level
+            icon={BootstrapIcon}
+            text={level.name}
+            tooltipContent={<p>{level.tooltipText}</p>}
+            textBoxHeightRem="7.6rem"
+          />
+        </Col>
+      );
+    });
   };
 
   return (

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -30,6 +30,22 @@ import Level from './Level';
  * @return {jsx} - the Levels One component to render
  */
 const LevelsContent = ({ attribute }) => {
+  // render content
+  const renderLevels = () => {
+    const mappedLevels = attribute.levels.map((level) => (
+      <Col key={level.name} md={2}>
+        <Level
+          icon={<level.icon size={30} />}
+          text={level.name}
+          tooltipContent={<p>{level.tooltipText}</p>}
+          textBoxHeightRem="7.6rem"
+        />
+      </Col>
+    ));
+
+    return mappedLevels;
+  };
+
   return (
     <Container fluid>
       <Container>
@@ -55,58 +71,7 @@ const LevelsContent = ({ attribute }) => {
               </Headline>
             </div>
 
-            <Row>
-              <Col md={2}>
-                <Level
-                  icon={<PersonCheck size={30} />}
-                  text="Employee assistance programs"
-                  tooltipContent={<p>Employee assistance programs tooltip!</p>}
-                  textBoxHeightRem="7.6rem"
-                />
-              </Col>
-              <Col md={2}>
-                <Level
-                  icon={<Basket size={30} />}
-                  text="Absence management and occupational health"
-                  tooltipContent={
-                    <p>Absence management and occupational health tooltip!</p>
-                  }
-                  textBoxHeightRem="7.6rem"
-                />
-              </Col>
-              <Col md={2}>
-                <Level
-                  icon={<Diagram3 size={30} />}
-                  text="Child care"
-                  tooltipContent={<p>Child care tooltip!</p>}
-                  textBoxHeightRem="7.6rem"
-                />
-              </Col>
-              <Col md={2}>
-                <Level
-                  icon={<HeartHalf size={30} />}
-                  text="Stress management"
-                  tooltipContent={<p>Stress management tooltip!</p>}
-                  textBoxHeightRem="7.6rem"
-                />
-              </Col>
-              <Col md={2}>
-                <Level
-                  icon={<PersonWorkspace size={30} />}
-                  text="Flexible and remote working"
-                  tooltipContent={<p>Flexible and remote working tooltip!</p>}
-                  textBoxHeightRem="7.6rem"
-                />
-              </Col>
-              <Col md={2}>
-                <Level
-                  icon={<HddNetwork size={30} />}
-                  text="Workstation assessments"
-                  tooltipContent={<p>Workstation assessments tooltip!</p>}
-                  textBoxHeightRem="7.6rem"
-                />
-              </Col>
-            </Row>
+            <Row>{renderLevels()}</Row>
 
             {/* Added div here to so main content
              * isn't blocked by footer, has space to scroll to view all body content

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -70,6 +70,7 @@ const LevelsContent = () => {
                   icon={<PersonCheck size={30} />}
                   text="Employee assistance programs"
                   tooltipContent={<p>Employee assistance programs tooltip!</p>}
+                  textBoxHeightRem="7.6rem"
                 />
               </Col>
               <Col md={2}>
@@ -86,6 +87,7 @@ const LevelsContent = () => {
                   icon={<Diagram3 size={30} />}
                   text="Child care"
                   tooltipContent={<p>Child care tooltip!</p>}
+                  textBoxHeightRem="7.6rem"
                 />
               </Col>
               <Col md={2}>
@@ -93,6 +95,7 @@ const LevelsContent = () => {
                   icon={<HeartHalf size={30} />}
                   text="Stress management"
                   tooltipContent={<p>Stress management tooltip!</p>}
+                  textBoxHeightRem="7.6rem"
                 />
               </Col>
               <Col md={2}>
@@ -100,6 +103,7 @@ const LevelsContent = () => {
                   icon={<PersonWorkspace size={30} />}
                   text="Flexible and remote working"
                   tooltipContent={<p>Flexible and remote working tooltip!</p>}
+                  textBoxHeightRem="7.6rem"
                 />
               </Col>
               <Col md={2}>
@@ -107,6 +111,7 @@ const LevelsContent = () => {
                   icon={<HddNetwork size={30} />}
                   text="Workstation assessments"
                   tooltipContent={<p>Workstation assessments tooltip!</p>}
+                  textBoxHeightRem="7.6rem"
                 />
               </Col>
             </Row>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -67,6 +67,14 @@ const LevelsContent = () => {
               <Level
                 icon={<PersonCheck size={30} />}
                 text="Employee assistance programs"
+                tooltip={
+                  <Tooltip
+                    contentClassName="bg-dark p-3 text-center"
+                    contentAbsoluteStartingPosition="left"
+                  >
+                    <p>Employee assistance programs tooltip!</p>
+                  </Tooltip>
+                }
               />
               <Level
                 icon={<Basket size={30} />}

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -90,6 +90,9 @@ const LevelsContent = () => {
               />
             </div>
 
+            {/* Added div here to so main content
+             * isn't blocked by footer, has space to scroll to view all body content
+             */}
             <div style={{ marginTop: '10rem' }}></div>
           </Col>
         </Row>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -26,6 +26,7 @@ import Level from './Level';
 
 /**
  * @description - returns Level One main body content
+ * @param {object} props.attribute - JSON properties containing specific attribute data
  * @return {jsx} - the Levels One component to render
  */
 const LevelsContent = ({ attribute }) => {

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -10,7 +10,14 @@
 
 // dependencies
 import { Container, Row, Col } from 'react-bootstrap';
-import { PersonCheck, Basket } from 'react-bootstrap-icons';
+import {
+  PersonCheck,
+  Basket,
+  Diagram3,
+  HeartHalf,
+  PersonWorkspace,
+  HddNetwork
+} from 'react-bootstrap-icons';
 // local files
 import Tooltip from '../shared/Tooltip';
 import Badge from '../shared/Badge';
@@ -57,7 +64,10 @@ const LevelsContent = () => {
             <div className="d-flex flex-column flex-sm-row">
               <Level icon={<PersonCheck size={30} />} />
               <Level icon={<Basket size={30} />} />
-              <Level />
+              <Level icon={<Diagram3 size={30} />} />
+              <Level icon={<HeartHalf size={30} />} />
+              <Level icon={<PersonWorkspace size={30} />} />
+              <Level icon={<HddNetwork size={30} />} />
             </div>
           </Col>
         </Row>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -18,6 +18,7 @@ import {
   HddNetwork
 } from 'react-bootstrap-icons';
 // local files
+import styles from './LevelsContent.module.css';
 import Tooltip from '../shared/Tooltip';
 import Badge from '../shared/Badge';
 import Headline from './Headline';
@@ -32,10 +33,7 @@ const LevelsContent = () => {
     <Container fluid>
       <Container>
         <Row
-          style={{
-            top: '8rem'
-          }}
-          className="position-relative w-100 h-100 align-items-center text-light"
+          className={`position-relative w-100 h-100 align-items-center text-light ${styles.row}`}
         >
           <Col>
             <div className="d-flex align-items-center">
@@ -93,7 +91,7 @@ const LevelsContent = () => {
             {/* Added div here to so main content
              * isn't blocked by footer, has space to scroll to view all body content
              */}
-            <div style={{ marginTop: '10rem' }}></div>
+            <div className={styles.marginDiv}></div>
           </Col>
         </Row>
       </Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -42,10 +42,7 @@ const LevelsContent = ({ attribute }) => {
                 contentClassName="bg-dark p-3 text-center"
                 contentAbsoluteStartingPosition="left"
               >
-                <p className="mb-0">
-                  Benefits that help support achieving a more optimal balance
-                  between work obligations and your other needs / obligations.
-                </p>
+                <p className="mb-0">{attribute.tooltipText}</p>
               </Tooltip>
               <Badge
                 className="bg-primary d-inline-block rounded-pill px-2 ms-3"

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -49,7 +49,7 @@ const LevelsContent = ({ attribute }) => {
       let BootstrapIcon = iconMap[level.icon];
 
       return (
-        <Col key={level.id} md={2}>
+        <Col key={level.levelId} md={2}>
           <Level
             icon={BootstrapIcon}
             text={level.name}

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -28,7 +28,9 @@ import Level from './Level';
  * @description - returns Level One main body content
  * @return {jsx} - the Levels One component to render
  */
-const LevelsContent = () => {
+const LevelsContent = ({ attribute }) => {
+  console.log(attribute);
+
   return (
     <Container fluid>
       <Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -80,6 +80,7 @@ const LevelsContent = () => {
                   tooltipContent={
                     <p>Absence management and occupational health tooltip!</p>
                   }
+                  textBoxHeightRem="7.6rem"
                 />
               </Col>
               <Col md={2}>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -43,7 +43,12 @@ const LevelsContent = () => {
             <Headline
               h1Text="Which of these work / life balance factors matters most to you?"
               h1ClassName="fw-bolder"
-            />
+            >
+              <p className="mb-0">
+                For each of the categories below, rate the item from 0-10 to
+                tell us how important that category is, compared to the others.
+              </p>
+            </Headline>
           </Col>
         </Row>
       </Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -30,7 +30,9 @@ const LevelsContent = ({ attribute }) => {
    */
   const renderLevels = () => {
     return attribute.levels.map((level) => {
-      // Icons is object with nested bootstrap icon name objects. Gets object matching level.icon name
+      /* Icons is object with nested bootstrap icon name objects. Gets object matching level.
+       * Rendering React components, so Icon variable must be capitalized.
+       */
       const Icon = Icons[level.icon];
 
       return (

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -55,6 +55,8 @@ const LevelsContent = () => {
             </div>
             <div>
               <Level />
+              <Level />
+              <Level />
             </div>
           </Col>
         </Row>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -79,20 +79,62 @@ const LevelsContent = () => {
               <Level
                 icon={<Basket size={30} />}
                 text="Absence management and occupational health"
+                tooltip={
+                  <Tooltip
+                    contentClassName="bg-dark p-3 text-center"
+                    contentAbsoluteStartingPosition="left"
+                  >
+                    <p>Absence management and occupational health tooltip!</p>
+                  </Tooltip>
+                }
               />
-              <Level icon={<Diagram3 size={30} />} text="Child care" />
-              <Level icon={<HeartHalf size={30} />} text="Stress management" />
               <Level
-                icon={
-                  <PersonWorkspace
-                    size={30}
-                    text="Flexible and remote working"
-                  />
+                icon={<Diagram3 size={30} />}
+                text="Child care"
+                tooltip={
+                  <Tooltip
+                    contentClassName="bg-dark p-3 text-center"
+                    contentAbsoluteStartingPosition="left"
+                  >
+                    <p>Child care tooltip!</p>
+                  </Tooltip>
+                }
+              />
+              <Level
+                icon={<HeartHalf size={30} />}
+                text="Stress management"
+                tooltip={
+                  <Tooltip
+                    contentClassName="bg-dark p-3 text-center"
+                    contentAbsoluteStartingPosition="left"
+                  >
+                    <p>Stress management tooltip!</p>
+                  </Tooltip>
+                }
+              />
+              <Level
+                icon={<PersonWorkspace size={30} />}
+                text="Flexible and remote working"
+                tooltip={
+                  <Tooltip
+                    contentClassName="bg-dark p-3 text-center"
+                    contentAbsoluteStartingPosition="left"
+                  >
+                    <p>Flexible and remote working tooltip!</p>
+                  </Tooltip>
                 }
               />
               <Level
                 icon={<HddNetwork size={30} />}
                 text="Workstation assessments"
+                tooltip={
+                  <Tooltip
+                    contentClassName="bg-dark p-3 text-center"
+                    contentAbsoluteStartingPosition="left"
+                  >
+                    <p>Workstation assessments tooltip!</p>
+                  </Tooltip>
+                }
               />
             </div>
 

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -32,8 +32,8 @@ const LevelsContent = () => {
     <Container fluid>
       <Container>
         <Row
-          style={{ top: '150px' }}
-          className="border position-relative w-100 h-100 align-items-center text-light"
+          style={{ top: '9.375rem' }}
+          className="position-relative w-100 h-100 align-items-center text-light"
         >
           <Col>
             <div className="d-flex align-items-center">

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -49,7 +49,7 @@ const LevelsContent = ({ attribute }) => {
       let BootstrapIcon = iconMap[level.icon];
 
       return (
-        <Col key={level.name} md={2}>
+        <Col key={level.id} md={2}>
           <Level
             icon={BootstrapIcon}
             text={level.name}

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -51,11 +51,7 @@ const LevelsContent = ({ attribute }) => {
             </div>
             <div className="mt-3">
               <Headline h1Text={attribute.displayName} h1ClassName="fw-bolder">
-                <p className="mb-0 pt-2">
-                  For each of the categories below, rate the item from 0-10 to
-                  tell us how important that category is, compared to the
-                  others.
-                </p>
+                <p className="mb-0 pt-2">{attribute.instructions}</p>
               </Headline>
             </div>
 

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -13,6 +13,7 @@ import { Container, Row, Col } from 'react-bootstrap';
 // local files
 import Tooltip from '../shared/Tooltip';
 import Badge from '../shared/Badge';
+import Headline from './Headline';
 
 /**
  * @description - returns Level One main body content
@@ -39,6 +40,10 @@ const LevelsContent = () => {
                 text="Work / Life Balance"
               />
             </div>
+            <Headline
+              h1Text="Which of these work / life balance factors matters most to you?"
+              h1ClassName="fw-bolder"
+            />
           </Col>
         </Row>
       </Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /*
  * Copyright (c) 2006-present TrueChoice IP Holding Company, Inc.
  * All rights reserved.

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -10,6 +10,7 @@
 
 // dependencies
 import { Container, Row, Col } from 'react-bootstrap';
+import { PersonCheck, Basket } from 'react-bootstrap-icons';
 // local files
 import Tooltip from '../shared/Tooltip';
 import Badge from '../shared/Badge';
@@ -53,9 +54,9 @@ const LevelsContent = () => {
                 </p>
               </Headline>
             </div>
-            <div>
-              <Level />
-              <Level />
+            <div className="d-flex flex-column flex-sm-row">
+              <Level icon={<PersonCheck size={30} />} />
+              <Level icon={<Basket size={30} />} />
               <Level />
             </div>
           </Col>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -30,8 +30,6 @@ import Level from './Level';
  * @return {jsx} - the Levels One component to render
  */
 const LevelsContent = ({ attribute }) => {
-  console.log(attribute);
-
   return (
     <Container fluid>
       <Container>
@@ -55,10 +53,7 @@ const LevelsContent = ({ attribute }) => {
               />
             </div>
             <div className="mt-3">
-              <Headline
-                h1Text="Which of these work / life balance factors matters most to you?"
-                h1ClassName="fw-bolder"
-              >
+              <Headline h1Text={attribute.displayName} h1ClassName="fw-bolder">
                 <p className="mb-0 pt-2">
                   For each of the categories below, rate the item from 0-10 to
                   tell us how important that category is, compared to the

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -14,6 +14,7 @@ import { Container, Row, Col } from 'react-bootstrap';
 import Tooltip from '../shared/Tooltip';
 import Badge from '../shared/Badge';
 import Headline from './Headline';
+import Level from './Level';
 
 /**
  * @description - returns Level One main body content
@@ -51,6 +52,9 @@ const LevelsContent = () => {
                   others.
                 </p>
               </Headline>
+            </div>
+            <div>
+              <Level />
             </div>
           </Col>
         </Row>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -63,40 +63,53 @@ const LevelsContent = () => {
                 </p>
               </Headline>
             </div>
-            <div className="d-flex flex-column flex-md-row">
-              <Level
-                icon={<PersonCheck size={30} />}
-                text="Employee assistance programs"
-                tooltipContent={<p>Employee assistance programs tooltip!</p>}
-              />
-              <Level
-                icon={<Basket size={30} />}
-                text="Absence management and occupational health"
-                tooltipContent={
-                  <p>Absence management and occupational health tooltip!</p>
-                }
-              />
-              <Level
-                icon={<Diagram3 size={30} />}
-                text="Child care"
-                tooltipContent={<p>Child care tooltip!</p>}
-              />
-              <Level
-                icon={<HeartHalf size={30} />}
-                text="Stress management"
-                tooltipContent={<p>Stress management tooltip!</p>}
-              />
-              <Level
-                icon={<PersonWorkspace size={30} />}
-                text="Flexible and remote working"
-                tooltipContent={<p>Flexible and remote working tooltip!</p>}
-              />
-              <Level
-                icon={<HddNetwork size={30} />}
-                text="Workstation assessments"
-                tooltipContent={<p>Workstation assessments tooltip!</p>}
-              />
-            </div>
+
+            <Row>
+              <Col md={2}>
+                <Level
+                  icon={<PersonCheck size={30} />}
+                  text="Employee assistance programs"
+                  tooltipContent={<p>Employee assistance programs tooltip!</p>}
+                />
+              </Col>
+              <Col md={2}>
+                <Level
+                  icon={<Basket size={30} />}
+                  text="Absence management and occupational health"
+                  tooltipContent={
+                    <p>Absence management and occupational health tooltip!</p>
+                  }
+                />
+              </Col>
+              <Col md={2}>
+                <Level
+                  icon={<Diagram3 size={30} />}
+                  text="Child care"
+                  tooltipContent={<p>Child care tooltip!</p>}
+                />
+              </Col>
+              <Col md={2}>
+                <Level
+                  icon={<HeartHalf size={30} />}
+                  text="Stress management"
+                  tooltipContent={<p>Stress management tooltip!</p>}
+                />
+              </Col>
+              <Col md={2}>
+                <Level
+                  icon={<PersonWorkspace size={30} />}
+                  text="Flexible and remote working"
+                  tooltipContent={<p>Flexible and remote working tooltip!</p>}
+                />
+              </Col>
+              <Col md={2}>
+                <Level
+                  icon={<HddNetwork size={30} />}
+                  text="Workstation assessments"
+                  tooltipContent={<p>Workstation assessments tooltip!</p>}
+                />
+              </Col>
+            </Row>
 
             {/* Added div here to so main content
              * isn't blocked by footer, has space to scroll to view all body content

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -40,15 +40,18 @@ const LevelsContent = () => {
                 text="Work / Life Balance"
               />
             </div>
-            <Headline
-              h1Text="Which of these work / life balance factors matters most to you?"
-              h1ClassName="fw-bolder"
-            >
-              <p className="mb-0">
-                For each of the categories below, rate the item from 0-10 to
-                tell us how important that category is, compared to the others.
-              </p>
-            </Headline>
+            <div className="mt-3">
+              <Headline
+                h1Text="Which of these work / life balance factors matters most to you?"
+                h1ClassName="fw-bolder"
+              >
+                <p className="mb-0 pt-2">
+                  For each of the categories below, rate the item from 0-10 to
+                  tell us how important that category is, compared to the
+                  others.
+                </p>
+              </Headline>
+            </div>
           </Col>
         </Row>
       </Container>

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -33,7 +33,7 @@ const LevelsContent = () => {
     <Container fluid>
       <Container>
         <Row
-          className={`position-relative border align-items-center text-light ${styles.row}`}
+          className={`position-relative align-items-center text-light ${styles.row}`}
         >
           <Col>
             <div className="d-flex align-items-center position-relative z-index-top">

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -40,6 +40,10 @@ const LevelsContent = ({ attribute }) => {
   };
 
   // render content
+  /**
+   * @description - maps over each level and displays the icon, text, & tooltip content
+   * @return {jsx} - Level component wrapped in Bootstrap Column
+   */
   const renderLevels = () => {
     return attribute.levels.map((level) => {
       let BootstrapIcon = iconMap[level.icon];

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -63,7 +63,7 @@ const LevelsContent = () => {
                 </p>
               </Headline>
             </div>
-            <div className="d-flex flex-column flex-sm-row">
+            <div className="d-flex flex-column flex-md-row">
               <Level
                 icon={<PersonCheck size={30} />}
                 text="Employee assistance programs"

--- a/components/body/LevelsContent.js
+++ b/components/body/LevelsContent.js
@@ -9,14 +9,7 @@
 
 // dependencies
 import { Container, Row, Col } from 'react-bootstrap';
-import {
-  PersonCheck,
-  Basket,
-  Diagram3,
-  HeartHalf,
-  PersonWorkspace,
-  HddNetwork
-} from 'react-bootstrap-icons';
+import * as Icons from 'react-bootstrap-icons';
 // local files
 import styles from './LevelsContent.module.css';
 import Tooltip from '../shared/Tooltip';
@@ -30,15 +23,6 @@ import Level from './Level';
  * @return {jsx} - the Levels One component to render
  */
 const LevelsContent = ({ attribute }) => {
-  const iconMap = {
-    Diagram3: <Diagram3 size={30} />,
-    Basket: <Basket size={30} />,
-    PersonCheck: <PersonCheck size={30} />,
-    HeartHalf: <HeartHalf size={30} />,
-    HddNetwork: <HddNetwork size={30} />,
-    PersonWorkspace: <PersonWorkspace size={30} />
-  };
-
   // render content
   /**
    * @description - maps over each level and displays the icon, text, & tooltip content
@@ -46,12 +30,13 @@ const LevelsContent = ({ attribute }) => {
    */
   const renderLevels = () => {
     return attribute.levels.map((level) => {
-      let BootstrapIcon = iconMap[level.icon];
+      // Icons is object with nested bootstrap icon name objects. Gets object matching level.icon name
+      const Icon = Icons[level.icon];
 
       return (
         <Col key={level.levelId} md={2}>
           <Level
-            icon={BootstrapIcon}
+            icon={<Icon size={30} />}
             text={level.name}
             tooltipContent={<p>{level.tooltipText}</p>}
             textBoxHeightRem="7.6rem"

--- a/components/body/LevelsContent.module.css
+++ b/components/body/LevelsContent.module.css
@@ -1,0 +1,7 @@
+.row {
+  top: 8rem;
+}
+
+.marginDiv {
+  margin-top: 10rem;
+}

--- a/components/body/LevelsContent.module.css
+++ b/components/body/LevelsContent.module.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-present TrueChoice IP Holding Company, Inc.
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of TrueChoice IP Holding Company, Inc.
+ * ("Confidential Information").  You shall not disclose such Confidential Information and shall
+ * use it only in accordance with the terms of the license agreement you entered into with the company.
+ */
+
 .row {
   top: 8rem;
 }

--- a/components/footer/Disclaimer.js
+++ b/components/footer/Disclaimer.js
@@ -28,7 +28,7 @@ const Disclaimer = ({
     <div>
       <small>
         <a
-          className="text-white"
+          className="text-white-50"
           href={copyrightLink}
           target="_blank"
           rel="noreferrer"
@@ -37,7 +37,7 @@ const Disclaimer = ({
         </a>{' '}
         |{' '}
         <a
-          className="text-white"
+          className="text-white-50"
           href={privacyLink}
           target="_blank"
           rel="noreferrer"

--- a/components/footer/Disclaimer.js
+++ b/components/footer/Disclaimer.js
@@ -25,7 +25,7 @@ const Disclaimer = ({
   privacyLink
 }) => {
   return (
-    <div>
+    <div className="text-white-50">
       <small>
         <a
           className="text-white-50"

--- a/components/shared/Tooltip.js
+++ b/components/shared/Tooltip.js
@@ -11,6 +11,7 @@
 import { useState } from 'react';
 import { InfoCircle, CaretUpFill } from 'react-bootstrap-icons';
 // local files
+import styles from './Tooltip.module.css';
 
 /**
  * @description - Tooltip icon. On click, opens a little text window
@@ -69,17 +70,12 @@ const Tooltip = ({
     return (
       open && (
         <div className="position-relative">
-          <CaretUpFill
-            className="text-dark"
-            size={24}
-            style={{
-              position: 'absolute',
-              top: '0.625rem',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-              margin: 'auto'
-            }}
-          />
+          <div>
+            <CaretUpFill
+              className={`text-dark position-absolute ${styles.caretUpFill}`}
+              size={24}
+            />
+          </div>
           <div
             className={`${contentClassName} position-absolute`}
             style={getContentStartPosition()}

--- a/components/shared/Tooltip.js
+++ b/components/shared/Tooltip.js
@@ -20,7 +20,7 @@ import { InfoCircle, CaretUpFill } from 'react-bootstrap-icons';
  * @returns {jsx} - the Tooltip component to render
  */
 const Tooltip = ({
-  contentClassName,
+  contentClassName = 'bg-dark',
   contentAbsoluteStartingPosition = 'center',
   children
 }) => {

--- a/components/shared/Tooltip.js
+++ b/components/shared/Tooltip.js
@@ -70,12 +70,10 @@ const Tooltip = ({
     return (
       open && (
         <div className="position-relative">
-          <div>
-            <CaretUpFill
-              className={`text-dark position-absolute ${styles.caretUpFill}`}
-              size={24}
-            />
-          </div>
+          <CaretUpFill
+            className={`text-dark position-absolute ${styles.caretUpFill}`}
+            size={24}
+          />
           <div
             className={`${contentClassName} position-absolute`}
             style={getContentStartPosition()}

--- a/components/shared/Tooltip.module.css
+++ b/components/shared/Tooltip.module.css
@@ -1,0 +1,6 @@
+.caretUpFill {
+  top: 0.625rem;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: auto;
+}

--- a/components/shared/Tooltip.module.css
+++ b/components/shared/Tooltip.module.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2006-present TrueChoice IP Holding Company, Inc.
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of TrueChoice IP Holding Company, Inc.
+ * ("Confidential Information").  You shall not disclose such Confidential Information and shall
+ * use it only in accordance with the terms of the license agreement you entered into with the company.
+ */
+
 .caretUpFill {
   top: 0.625rem;
   left: 50%;

--- a/data/application.json
+++ b/data/application.json
@@ -7,31 +7,37 @@
       "instructions": "For each of the categories below, rate the item from 0-10 to tell us how important that category is, compared to the others.",
       "levels": [
         {
+          "levelId": 1,
           "name": "Employee assistance programs",
           "tooltipText": "Employee assitance programs tooltip!",
           "icon": "PersonCheck"
         },
         {
+          "levelId": 2,
           "name": "Absence management and occupational health",
           "tooltipText": "Absence management and occupational health tooltip!",
           "icon": "Basket"
         },
         {
+          "levelId": 3,
           "name": "Child care",
           "tooltipText": "Child care tooltip!",
           "icon": "Diagram3"
         },
         {
+          "levelId": 4,
           "name": "Stress management",
           "tooltipText": "Stress management tooltip",
           "icon": "HeartHalf"
         },
         {
+          "levelId": 5,
           "name": "Flexible and remote working",
           "tooltipText": "Flexible and remote working tooltip!",
           "icon": "PersonWorkspace"
         },
         {
+          "levelId": 6,
           "name": "Workstation assessments",
           "tooltipText": "Workstation assessments tooltip!",
           "icon": "HddNetwork"

--- a/data/application.json
+++ b/data/application.json
@@ -8,7 +8,7 @@
       "levels": [
         {
           "name": "Employee assistance programs",
-          "tooltip": "Employee assitance programs tooltip!",
+          "tooltipText": "Employee assitance programs tooltip!",
           "icon": "PersonCheck"
         }
       ]

--- a/data/application.json
+++ b/data/application.json
@@ -3,7 +3,7 @@
     {
       "name": "Work / Life Balance",
       "tooltipText": "Benefits that help support achieving a more optimal balance between work obligations and your other needs / obligations.",
-      "displayName": "Which of these work / life balance factors matters most to you",
+      "displayName": "Which of these work / life balance factors matters most to you?",
       "instructions": "For each of the categories below, rate the item from 0-10 to tell us how important that category is, compared to the others.",
       "levels": [
         {

--- a/data/application.json
+++ b/data/application.json
@@ -10,6 +10,31 @@
           "name": "Employee assistance programs",
           "tooltipText": "Employee assitance programs tooltip!",
           "icon": "PersonCheck"
+        },
+        {
+          "name": "Absence management and occupational health",
+          "tooltipText": "Absence management and occupational health tooltip!",
+          "icon": "Basket"
+        },
+        {
+          "name": "Child care",
+          "tooltipText": "Child care tooltip!",
+          "icon": "Diagram3"
+        },
+        {
+          "name": "Stress management",
+          "tooltipText": "Stress management tooltip",
+          "icon": "HeartHalf"
+        },
+        {
+          "name": "Flexible and remote working",
+          "tooltipText": "Flexible and remote working tooltip!",
+          "icon": "PersonWorkspace"
+        },
+        {
+          "name": "Workstation assessments",
+          "tooltipText": "Workstation assessments tooltip!",
+          "icon": "HddNetwork"
         }
       ]
     }

--- a/data/application.json
+++ b/data/application.json
@@ -1,0 +1,17 @@
+{
+  "attributes": [
+    {
+      "name": "Work / Life Balance",
+      "tooltipText": "Benefits that help support achieving a more optimal balance between work obligations and your other needs / obligations.",
+      "displayName": "Which of these work / life balance factors matters most to you",
+      "instructions": "For each of the categories below, rate the item from 0-10 to tell us how important that category is, compared to the others.",
+      "levels": [
+        {
+          "name": "Employee assistance programs",
+          "tooltip": "Employee assitance programs tooltip!",
+          "icon": "PersonCheck"
+        }
+      ]
+    }
+  ]
+}

--- a/pages/levels.js
+++ b/pages/levels.js
@@ -14,12 +14,17 @@ import BackgroundOverlayTint from '../components/background/BackgroundOverlayTin
 import Header from '../components/header/Header';
 import LevelsContent from '../components/body/LevelsContent';
 import Footer from '../components/footer/Footer';
+import applicationData from '../data/application.json';
 
 /**
  * @description - returns Levels One Page
  * @return {jsx} - the Levels One Page to render
  */
 const Levels = () => {
+  const attribute = applicationData.attributes[0];
+
+  console.log(attribute);
+
   return (
     <main>
       {/* eslint-disable-next-line max-len */}

--- a/pages/levels.js
+++ b/pages/levels.js
@@ -21,9 +21,8 @@ import applicationData from '../data/application.json';
  * @return {jsx} - the Levels One Page to render
  */
 const Levels = () => {
+  // retrieve first attribute data
   const attribute = applicationData.attributes[0];
-
-  console.log(attribute);
 
   return (
     <main>

--- a/pages/levels.js
+++ b/pages/levels.js
@@ -34,7 +34,7 @@ const Levels = () => {
         endColor="purple"
       />
       <Header text="Learn: 1 of 5" progressBarValue="25" />
-      <LevelsContent />
+      <LevelsContent attribute={attribute} />
       <Footer>
         <p className="w-75 mb-3">
           This question is asking you to state your preferences across a range

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,7 +31,7 @@ a {
 input[type='range'][orient='vertical'] {
   writing-mode: bt-lr; /* IE */
   -webkit-appearance: slider-vertical; /* Chromium */
-  width: 8px;
-  height: 175px;
-  padding: 0 5px;
+  width: 0.5rem;
+  height: 10.9375rem;
+  padding: 0 0.3125rem;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,49 +28,10 @@ a {
   z-index: -1;
 }
 
-/* Chrome */
-@media screen and (-webkit-min-device-pixel-ratio: 0) {
-  input[type='range'] {
-    overflow: hidden;
-    width: 80px;
-    -webkit-appearance: none;
-    background-color: #9a905d;
-  }
-
-  input[type='range']::-webkit-slider-runnable-track {
-    height: 10px;
-    -webkit-appearance: none;
-    color: #13bba4;
-    margin-top: -1px;
-  }
-
-  input[type='range']::-webkit-slider-thumb {
-    width: 10px;
-    -webkit-appearance: none;
-    height: 10px;
-    cursor: ew-resize;
-    background: #434343;
-    box-shadow: -80px 0 0 80px #43e5f7;
-  }
-}
-
-/* Firefox */
-input[type='range']::-moz-range-progress {
-  background-color: pink;
-  height: 0.5rem;
-}
-input[type='range']::-moz-range-track {
-  background-color: #9a905d;
-}
-
-input[type='range']::-moz-range-track {
-  background-color: red;
-}
-
-/* IE*/
-input[type='range']::-ms-fill-lower {
-  background-color: #43e5f7;
-}
-input[type='range']::-ms-fill-upper {
-  background-color: #9a905d;
+input[type='range'][orient='vertical'] {
+  writing-mode: bt-lr; /* IE */
+  -webkit-appearance: slider-vertical; /* Chromium */
+  width: 8px;
+  height: 175px;
+  padding: 0 5px;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -27,3 +27,50 @@ a {
 .z-index-bottom {
   z-index: -1;
 }
+
+/* Chrome */
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input[type='range'] {
+    overflow: hidden;
+    width: 80px;
+    -webkit-appearance: none;
+    background-color: #9a905d;
+  }
+
+  input[type='range']::-webkit-slider-runnable-track {
+    height: 10px;
+    -webkit-appearance: none;
+    color: #13bba4;
+    margin-top: -1px;
+  }
+
+  input[type='range']::-webkit-slider-thumb {
+    width: 10px;
+    -webkit-appearance: none;
+    height: 10px;
+    cursor: ew-resize;
+    background: #434343;
+    box-shadow: -80px 0 0 80px #43e5f7;
+  }
+}
+
+/* Firefox */
+input[type='range']::-moz-range-progress {
+  background-color: pink;
+  height: 0.5rem;
+}
+input[type='range']::-moz-range-track {
+  background-color: #9a905d;
+}
+
+input[type='range']::-moz-range-track {
+  background-color: red;
+}
+
+/* IE*/
+input[type='range']::-ms-fill-lower {
+  background-color: #43e5f7;
+}
+input[type='range']::-ms-fill-upper {
+  background-color: #9a905d;
+}


### PR DESCRIPTION
# Background
Levels content complete. Primary goal was to lay out body for Levels page.
*Note* will break down Level component further, thinking of two components: 1 to store icon + tooltip + text, 1 for only range slider (need to further style input).

# Breaking Changes
None

# Updates
- LevelsContent: margin-top div added on bottom to give spacing between footer & body. Body does not take full vw/vh anymore (unable to scroll down if more content is added, sliders were being cut off). Headline, icon, tooltip, text, slider range added.
- Level: Uses Tooltip component. textBotHeightRem prop sets attributes text blocks to same height, so sliders won't be offset. Comments show what to hide/show based on screen size.
- globals.css: orient vertical makes slider range vertical on medium+ screens.

# Example Links
screen size < 768px
![Screenshot 2022-03-21 at 08-38-21 Screenshot](https://user-images.githubusercontent.com/97993162/159296726-dcfd5a6a-15d2-4b19-88a3-3b70c510965f.png)

screen size >= 768px
![Screenshot 2022-03-21 at 08-36-18 Screenshot](https://user-images.githubusercontent.com/97993162/159296305-3fbdd4d9-356e-411b-9fc1-98dbf98a6f1b.png)
# Key Files
LevelsContent.js, Level.js

